### PR TITLE
[2.0.0] Fix compatibility with Micro\Collection::map() when no verb used

### DIFF
--- a/phalcon/mvc/micro.zep
+++ b/phalcon/mvc/micro.zep
@@ -436,7 +436,7 @@ class Micro extends Injectable implements \ArrayAccess
 				 */
 				let route = this->map(prefixedPattern, realHandler);
 
-				if typeof methods == "string" || typeof methods == "array" {
+				if (typeof methods == "string" && methods != "") || typeof methods == "array" {
 					route->via(methods);
 				}
 


### PR DESCRIPTION
The method map() [sends](https://github.com/phalcon/cphalcon/blob/2.0.0/phalcon/mvc/micro/collection.zep#L153) a null verb to [_addMap](https://github.com/phalcon/cphalcon/blob/2.0.0/phalcon/mvc/micro/collection.zep#L61) and it's fine when you add a controllers as handlers.

This worked with 1.\* but in 2.0 it's casted to an empty string.
This patch solves the problem when the route tries to add null verbs
